### PR TITLE
 [intfutil] add Asymmetric PFC status to 'show interface status' 

### DIFF
--- a/scripts/intfutil
+++ b/scripts/intfutil
@@ -21,6 +21,7 @@ PORT_SPEED = "speed"
 PORT_MTU_STATUS = "mtu"
 PORT_DESCRIPTION = "description"
 PORT_OPTICS_TYPE = "type"
+PORT_PFC_ASYM_STATUS = "pfc_asym"
 
 
 def db_connect_appl():
@@ -84,7 +85,7 @@ def state_db_port_optics_get(state_db, intf_name, type):
 
 # ========================== interface-status logic ==========================
 
-header_stat = ['Interface', 'Lanes', 'Speed', 'MTU', 'Alias', 'Oper', 'Admin', 'Type']
+header_stat = ['Interface', 'Lanes', 'Speed', 'MTU', 'Alias', 'Oper', 'Admin', 'Type', 'Asym PFC']
 
 class IntfStatus(object):
 
@@ -111,7 +112,8 @@ class IntfStatus(object):
                               appl_db_port_status_get(self.appl_db, key, PORT_ALIAS),
                               appl_db_port_status_get(self.appl_db, key, PORT_OPER_STATUS),
                               appl_db_port_status_get(self.appl_db, key, PORT_ADMIN_STATUS),
-                              state_db_port_optics_get(self.state_db, key, PORT_OPTICS_TYPE)))
+                              state_db_port_optics_get(self.state_db, key, PORT_OPTICS_TYPE),
+                              appl_db_port_status_get(self.appl_db, key, PORT_PFC_ASYM_STATUS)))
 
         # Sorting and tabulating the result table.
         sorted_table = natsorted(table)

--- a/show/main.py
+++ b/show/main.py
@@ -746,29 +746,6 @@ def pwm_pg_shared():
     command = 'watermarkstat -p -t pg_shared'
     run_command(command)
 
-#
-# 'pfc' group ###
-#
-
-@interfaces.group(cls=AliasedGroup, default_if_no_args=False)
-def pfc():
-    """Show PFC information"""
-    pass
-
-
-#
-# 'pfc status' command ###
-#
-
-@pfc.command()
-@click.argument('interface', type=click.STRING, required=False)
-def status(interface):
-    """Show PFC information"""
-    if interface is None:
-        interface = ""
-
-    run_command("pfc show asymmetric {0}".format(interface))
-
 
 #
 # 'mac' command ("show mac ...")


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
 - remove 'show interfaces pfc status'
 - add 'Asymmetric PFC' status to the output of 'show interfaces status' 
**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ show interface pfc status

Interface    Asymmetric
-----------  ------------
Ethernet0    on
Ethernet4    N/A
Ethernet8    N/A
Ethernet12   N/A
```
**- New command output (if the output of a command-line utility has changed)**
```
admin@sonic:~$ show interface status
  Interface            Lanes    Speed    MTU    Alias    Oper    Admin    Type    Asym PFC
-----------  ---------------  -------  -----  -------  ------  -------  ------  ----------
  Ethernet0          0,1,2,3      40G   9100     etp1      up       up   QSFP+          on
  Ethernet4          4,5,6,7      40G   9100     etp2      up       up   QSFP+         N/A
  Ethernet8        8,9,10,11      40G   9100     etp3      up       up   QSFP+         N/A
 Ethernet12      12,13,14,15      40G   9100     etp4      up       up   QSFP+         N/A

```
-->

