### PR TITLE
[counterpoll] add port buffer drop group

### DIFF
--- a/counterpoll/main.py
+++ b/counterpoll/main.py
@@ -5,7 +5,9 @@ import swsssdk
 from tabulate import tabulate
 
 BUFFER_POOL_WATERMARK = "BUFFER_POOL_WATERMARK"
+PORT_BUFFER_DROP = "PORT_BUFFER_DROP"
 DISABLE = "disable"
+DEFLT_60_SEC= "default (60000)"
 DEFLT_10_SEC= "default (10000)"
 DEFLT_1_SEC = "default (1000)"
 
@@ -80,6 +82,46 @@ def disable():
     port_info = {}
     port_info['FLEX_COUNTER_STATUS'] = 'disable'
     configdb.mod_entry("FLEX_COUNTER_TABLE", "PORT", port_info)
+
+# Port buffer drop counter commands
+@cli.group()
+def port_buffer_drop():
+    """ Port buffer drop  counter commands """
+
+@port_buffer_drop.command()
+@click.argument('poll_interval', type=click.IntRange(30000, 300000))
+def interval(poll_interval):
+    """
+    Set port_buffer_drop counter query interval
+    This counter group causes high CPU usage when polled,
+    hence the allowed interval is between 30s and 300s.
+    This is a ahort term solution and
+    should be changed once the performance is enhanced
+    """
+    configdb = swsssdk.ConfigDBConnector()
+    configdb.connect()
+    port_info = {}
+    if poll_interval is not None:
+        port_info['POLL_INTERVAL'] = poll_interval
+    configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_BUFFER_DROP, port_info)
+
+@port_buffer_drop.command()
+def enable():
+    """ Enable port counter query """
+    configdb = swsssdk.ConfigDBConnector()
+    configdb.connect()
+    port_info = {}
+    port_info['FLEX_COUNTER_STATUS'] = 'enable'
+    configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_BUFFER_DROP, port_info)
+
+@port_buffer_drop.command()
+def disable():
+    """ Disable port counter query """
+    configdb = swsssdk.ConfigDBConnector()
+    configdb.connect()
+    port_info = {}
+    port_info['FLEX_COUNTER_STATUS'] = 'disable'
+    configdb.mod_entry("FLEX_COUNTER_TABLE", PORT_BUFFER_DROP, port_info)
 
 # RIF counter commands
 @cli.group()
@@ -166,6 +208,7 @@ def show():
     configdb.connect()
     queue_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'QUEUE')
     port_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'PORT')
+    port_drop_info = configdb.get_entry('FLEX_COUNTER_TABLE', PORT_BUFFER_DROP)
     rif_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'RIF')
     queue_wm_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'QUEUE_WATERMARK')
     pg_wm_info = configdb.get_entry('FLEX_COUNTER_TABLE', 'PG_WATERMARK')
@@ -177,6 +220,8 @@ def show():
         data.append(["QUEUE_STAT", queue_info.get("POLL_INTERVAL", DEFLT_10_SEC), queue_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if port_info:
         data.append(["PORT_STAT", port_info.get("POLL_INTERVAL", DEFLT_1_SEC), port_info.get("FLEX_COUNTER_STATUS", DISABLE)])
+    if port_drop_info:
+        data.append([PORT_BUFFER_DROP, port_drop_info.get("POLL_INTERVAL", DEFLT_60_SEC), port_drop_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if rif_info:
         data.append(["RIF_STAT", rif_info.get("POLL_INTERVAL", DEFLT_1_SEC), rif_info.get("FLEX_COUNTER_STATUS", DISABLE)])
     if queue_wm_info:


### PR DESCRIPTION
Signed-off-by: Mykola Faryma <mykolaf@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged.

If you are adding/modifying/removing any command or utility script, please also
make sure to add/modify/remove any unit tests from the sonic-utilities-tests
directory as appropriate.

If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
subcommand, or you are adding a new subcommand, please make sure you also
update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
your changes.

Please provide the following information:
-->
Introducing separate FC group for port lever buffer drop counters as discussed in https://github.com/Azure/sonic-swss/pull/1308
**- What I did**

**- How I did it**

**- How to verify it**

**- Previous command output (if the output of a command-line utility has changed)**

**- New command output (if the output of a command-line utility has changed)**

